### PR TITLE
Add conditional to Polynucleotide.sequence to prevent errors in Sheets

### DIFF
--- a/src/C6-Seq.js
+++ b/src/C6-Seq.js
@@ -111,7 +111,7 @@ function cleanup(sequence) {
    */
   class Polynucleotide {
     constructor(sequence, ext5 = null, ext3 = null, isDoubleStranded, isRNA, isCircular, mod_ext5, mod_ext3) {
-      this.sequence = sequence.toUpperCase();
+      this.sequence = sequence ? sequence.toUpperCase() : sequence;
       this.ext5 = ext5 ? ext5.toUpperCase() : ext5;
       this.ext3 = ext3 ? ext3.toUpperCase() : ext3;
       this.isDoubleStranded = isDoubleStranded;


### PR DESCRIPTION
Initializing a new empty Polynucleotide breaks since `.toUpperCase()` cannot accept `undefined` as an input. I added the same conditional statements as those for `ext5` and `ext3` to prevent any errors in a function I wrote for Apps Script compatibility.